### PR TITLE
make cscope.out connect automatic and correctly when open a file in subdirectories

### DIFF
--- a/plugin/cscope_macros.vim
+++ b/plugin/cscope_macros.vim
@@ -39,10 +39,17 @@ if has("cscope")
 
     " add any cscope database in current directory
     if filereadable("cscope.out")
-        cs add cscope.out  
+        cs add cscope.out %:p:h
     " else add the database pointed to by environment variable 
     elseif $CSCOPE_DB != ""
         cs add $CSCOPE_DB
+    " else add any cscope database in upwards directories
+    else
+        let cscope_file=findfile("cscope.out", ".;")
+        let cscope_pre=fnamemodify(cscope_file, ':p:h')
+        if !empty(cscope_file) && filereadable(cscope_file)
+            exe "cs add" cscope_file cscope_pre
+        endif
 	endif
 
     " show msg when any other cscope db added


### PR DESCRIPTION
**Puspose**
To fix a problem I ever met. It's description is below.

**Problem Description**
If there is a directory tree like this:

```
D:\CSCOPE_TEST
│  cscope.out
│  main.cpp
│
└─headers
        functions.cpp
        functions.h
```

If I work with original cscope_macros.vim plugin, when I open `main.cpp`, it will connect cscope.out automatic and correctly. But if I switch to files in subdir `headers` use the same vim instance, cscope won't work. And if I open `functsions.cpp` or `functions.h` with vim directly, cscope won't work neither.
